### PR TITLE
Lombok 라이브러리 추가 및 의존성 주입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,12 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    testImplementation 'org.projectlombok:lombok:1.18.22'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/demo/controller/MenuController.java
+++ b/src/main/java/com/example/demo/controller/MenuController.java
@@ -1,0 +1,13 @@
+package com.example.demo.controller;
+
+import com.example.demo.service.MenuService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class MenuController {
+
+    private final MenuService menuService;
+
+}

--- a/src/main/java/com/example/demo/repository/MenuRepository.java
+++ b/src/main/java/com/example/demo/repository/MenuRepository.java
@@ -1,0 +1,4 @@
+package com.example.demo.repository;
+
+public interface MenuRepository {
+}

--- a/src/main/java/com/example/demo/service/MenuService.java
+++ b/src/main/java/com/example/demo/service/MenuService.java
@@ -1,0 +1,4 @@
+package com.example.demo.service;
+
+public interface MenuService {
+}

--- a/src/main/java/com/example/demo/service/MenuServiceImpl.java
+++ b/src/main/java/com/example/demo/service/MenuServiceImpl.java
@@ -1,0 +1,13 @@
+package com.example.demo.service;
+
+import com.example.demo.repository.MenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MenuServiceImpl implements MenuService{
+
+    private final MenuRepository menuRepository;
+
+}


### PR DESCRIPTION
1. Lombok 라이브러리 추가
- Lombok의 @RequiredArgsConstructor 어노테이션을 사용하기 위하여 build.gradle에 Lombok 라이브러리를 추가했습니다.
2. 각 계층 클래스 생성
- Controller, Service, Repository 클래스를 생성하였습니다.
- Service, Repository 클래스는 인터페이스로 생성하여, 추후 다른 클래스의 객체로 쉽게 변경할 수 있도록 했습니다.
3. 생성자 주입을 사용하여 DI 구현
- final 키워드와 @RequiredArgsConstructor를 사용하여 간결하게 작성했습니다.